### PR TITLE
Ignore .venv so Docker builds correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /venv
+/.venv
 poetry.lock
 test.db
 /media


### PR DESCRIPTION
The `.dockerignore` file currently contains a `/venv` entry, but if installing dependencies locally with Poetry, the virtual environment directory created is called `/.venv`. So when building, Docker pulls in that directory and attempts to use it, which causes errors. Ignoring the `/.venv` directory as well resolves this. 